### PR TITLE
Fix year/semester click

### DIFF
--- a/js/malla.js
+++ b/js/malla.js
@@ -283,16 +283,27 @@ class Malla {
                 .text(this.romanize(intToRomanize))
                 .attr("dominant-baseline", "central")
                 .attr('text-anchor', 'middle');
+
             // evento en caso de clickear la barra del semestre
             semesterIndicator.on("click", () => {
                 let bar = d3.select(d3.event.currentTarget)
                 let semNumber = this.deRomanize(bar.select("text").text());
+                
                 if (semester[0] === "s")
                     semNumber = "s" + semNumber
-                Object.values(this.malla[semNumber]).forEach(ramo => {
-                    ramo.isBeingClicked()
-                })
 
+                const ramos = Object.values(this.malla[semNumber])
+                const allApproved = Object.values(ramos).every(ramo => ramo.approved)
+                const noneApproved = Object.values(ramos).every(ramo => !ramo.approved)
+
+                if (allApproved || noneApproved) {
+                    ramos.forEach(ramo => ramo.isBeingClicked())
+                } else {
+                    ramos.forEach(ramo => {
+                        if(!ramo.approved) ramo.isBeingClicked()
+                    })
+                    
+                }
             });
 
             globalY += semesterIndicatorHeight + separator;

--- a/js/malla.js
+++ b/js/malla.js
@@ -62,8 +62,7 @@ class Malla {
             let data = JSON.parse(unparsedData)
             this.currentMalla = data.name;
             this.fullCareerName = data.name
-            console.log("hola")
-            console.log(data.name)
+            // console.log(data.name)
             return Promise.resolve(this.setMallaAndCategories(data.malla, data.categories))
 
         } else {
@@ -212,12 +211,32 @@ class Malla {
                     let bar = d3.select(d3.event.currentTarget)
                     let number = parseInt(bar.select("text").text().substr(4));
                     let ramosToSelect;
-                if (bar.node().getBBox().width <= this.subjectType.getDisplayWidth(this.scaleX) * 2 - this.subjectType.getDisplayWidth(this.scaleX) / 2) {
-                    d3.select("#sem" + (number * 2 + 1)).dispatch('click')
-                } else {
-                    d3.select("#sem" + number * 2).dispatch('click');
-                    d3.select("#sem" + (number * 2 - 1)).dispatch('click')
+                    const areAllRamosApproved = (semNumber) => {
+                        semester = "s" + semNumber
+                        const ramos = Object.values(this.malla[semester]);
+                        return ramos.every(ramo => ramo.approved)
+                    }
+                    let sem1 = number * 2 + 1
+                    let sem2 = number * 2
+                    let sem3 = number * 2 - 1
 
+                    const sem1Approved = areAllRamosApproved(sem1)
+                    const sem2Approved = areAllRamosApproved(sem2)
+                    const sem3Approved = areAllRamosApproved(sem3)
+
+                if (bar.node().getBBox().width <= this.subjectType.getDisplayWidth(this.scaleX) * 2 - this.subjectType.getDisplayWidth(this.scaleX) / 2) {
+                    if (sem1Approved){
+                        d3.select("#sem" + sem1).dispatch('click')
+                    }
+                } else {
+                    if ((sem2Approved && sem3Approved) || (!sem2Approved && !sem3Approved)) {
+                        d3.select("#sem" + sem2).dispatch('click')
+                        d3.select("#sem" + sem3).dispatch('click')
+                    } else if (!sem2Approved) {
+                        d3.select("#sem" + sem2).dispatch('click')
+                    } else if (!sem3Approved) {
+                        d3.select("#sem" + sem3).dispatch('click')
+                    }
                 }
 
                 });
@@ -648,7 +667,7 @@ class Malla {
                 document.getElementById("carrColor2").textContent = input.target.value.toUpperCase()
                 document.getElementById('dMalla').setAttribute('download', "data_" + input.target.value.toUpperCase() + '.json')
                 document.getElementById('dColor').setAttribute("download", "colors_" + input.target.value.toUpperCase() + '.json')
-                console.log(this.generatedCode[0])
+                // console.log(this.generatedCode[0])
                 this.generatedCode[0] = input.target.value
 
                 $('[data-toggle="tooltip"]').tooltip()


### PR DESCRIPTION
Existía un bug que realizaba un alternado entre los ramos ya aprobados al hacer click.
Estado 1:
![imagen](https://github.com/user-attachments/assets/2211874c-9e72-4da0-a3c4-df5d776a176b)

Se hacía click en el año/semestre y quedaba así:
![imagen](https://github.com/user-attachments/assets/e3532c9a-4667-41cf-b9f7-e611a2b534be)


Con este PR se soluciona y se agrega un poquito de lógica para gestionar esto.